### PR TITLE
Properly handle porcelain error on do_process

### DIFF
--- a/lib/iona/processing.ex
+++ b/lib/iona/processing.ex
@@ -102,7 +102,7 @@ defmodule Iona.Processing do
                       executable_default_args(processor) ++ [basename],
                       dir: dirname, out: :string) do
                   %{status: 0} -> {:ok, %Iona.Document{format: format, output_path: output_path}}
-                  failure -> {:error, "Processing failed with output: #{failure.out}"}
+                  {:error, err} -> {:error, "Processing failed with output: #{err}"}
                 end
               err -> err
             end


### PR DESCRIPTION
This seems to be updated for other functions but not on do_process which means missing processor executable would throw error and not return error tuple as meant to.