### PR TITLE
Use System.cmd/3 instead of erlexec

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,6 @@ defmodule Iona.Mixfile do
   defp deps do
     [
       {:briefly, "~> 0.3"},
-      {:exexec, "~> 0.2"},
       {:dialyxir, "~> 1.0-rc", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.0.0", only: [:dev]},
       {:credo, "~> 1.1.0", only: [:dev], runtime: false}


### PR DESCRIPTION
`erlexec` patronizes users not to use `root` to run commands. Therefore it's not possible to run it in common scenarios like CI/CD with Docker etc. Therefore the lib is removed.