### PR TITLE
Clarify Input.t() as either Source.t() or Template.t()

### DIFF
--- a/lib/iona/input.ex
+++ b/lib/iona/input.ex
@@ -1,5 +1,5 @@
 defprotocol Iona.Input do
-  @type t :: any
+  @type t :: Iona.Source.t() | Iona.Template.t()
 
   @spec path?(input :: t) :: boolean
   def path?(input)


### PR DESCRIPTION
I have run into a dialyzer issue when integrating Iona into my application.

Code:
```
Iona.source("\\documentclass[a4paper,12pt]{article}\n\n\\begin{document}\n\nSome content\n\\end{document}")
|> Iona.to(:pdf)
```

Error:
```
The function call will not succeed.

Iona.to(
  %Iona.Source{
    :content => binary(),
    :include => [
      binary()
      | maybe_improper_list(
          binary() | maybe_improper_list(any(), binary() | []) | char(),
          binary() | []
        )
    ],
    :path =>
      binary()
      | maybe_improper_list(
          binary() | maybe_improper_list(any(), binary() | []) | char(),
          binary() | []
        )
  },
  :pdf
)

will never return since it differs in arguments with
positions 1st from the success typing arguments:

(Iona.Input, atom())
```

My suspicion is that `Iona.Input.t()` was actually a wrapper for what could either be an `Iona.Source.t()` or an `Iona.Template.t()`. With the proposed change, dialyzer no longer complains.