### PR TITLE
Fix implementation

### DIFF
--- a/lib/iona/template/engine.ex
+++ b/lib/iona/template/engine.ex
@@ -46,7 +46,7 @@ defmodule Iona.Template.Engine do
   end
 
   @impl true
-  def handle_text(state, text) do
+  def handle_text(state, _meta, text) do
     %{iodata: iodata} = state
     %{state | iodata: [text | iodata]}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -37,9 +37,9 @@ defmodule Iona.Mixfile do
   defp deps do
     [
       {:briefly, "~> 0.3"},
-      {:dialyxir, "~> 1.0-rc", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.1", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.0.0", only: [:dev]},
-      {:credo, "~> 1.1.0", only: [:dev], runtime: false}
+      {:credo, "~> 1.5", only: [:dev], runtime: false}
     ]
   end
 


### PR DESCRIPTION
Fixed handle_text/3 implementation based on [doc](https://hexdocs.pm/eex/EEx.Engine.html#handle_text/3)
```elixir
warning: got "@impl true" for function handle_text/2 but no behaviour specifies such callback. The known callbacks are:

  * EEx.Engine.handle_begin/1 (function)
  * EEx.Engine.handle_body/1 (function)
  * EEx.Engine.handle_end/1 (function)
  * EEx.Engine.handle_expr/3 (function)
  * EEx.Engine.handle_text/3 (function)
  * EEx.Engine.init/1 (function)

  lib/iona/template/engine.ex:49: Iona.Template.Engine (module)

warning: function handle_text/3 required by behaviour EEx.Engine is not implemented (in module Iona.Template.Engine)
  lib/iona/template/engine.ex:4: Iona.Template.Engine (module)
```